### PR TITLE
Remove AD_ID permission from AndroidManifest

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
The `com.google.android.gms.permission.AD_ID` permission is removed from the `AndroidManifest.xml` file using `tools:node="remove"`. This is likely because the IMA SDK version 3.25.1 or higher, which is probably being used, automatically declares this permission.